### PR TITLE
Add render parameters

### DIFF
--- a/src/datasource/render/backend.ts
+++ b/src/datasource/render/backend.ts
@@ -101,16 +101,16 @@ export class TileChunkSource extends WithParameters(
     const { parameters } = this;
     const query_params = new URLSearchParams();
 
-	if (parameters.channel !== undefined) {
-		query_params.append("channel", parameters.channel);
-	}
+    if (parameters.channel !== undefined) {
+      query_params.append("channel", parameters.channel);
+    }
 
-	// Parse fallback key-value argument
-	for (const [key, value] of Object.entries(parameters.renderArgs)) {
-		query_params.append(key, value);
-	}
+    // Parse fallback key-value argument
+    for (const [key, value] of Object.entries(parameters.renderArgs)) {
+      query_params.append(key, value);
+    }
 
-	return query_params.toString();
+    return query_params.toString();
   })();
 
   async download(chunk: VolumeChunk, signal: AbortSignal) {

--- a/src/datasource/render/backend.ts
+++ b/src/datasource/render/backend.ts
@@ -15,6 +15,7 @@
  */
 
 import { decodeJpeg } from "#src/async_computation/decode_jpeg_request.js";
+import { decodePng } from "#src/async_computation/decode_png_request.js";
 import { requestAsyncComputation } from "#src/async_computation/request.js";
 import { WithParameters } from "#src/chunk_manager/backend.js";
 import { TileChunkSourceParameters } from "#src/datasource/render/base.js";
@@ -43,6 +44,44 @@ chunkDecoders.set(
       chunkDataSize[0] * chunkDataSize[1] * chunkDataSize[2],
       3,
       true,
+    );
+    await postProcessRawData(chunk, signal, decoded);
+  },
+);
+chunkDecoders.set(
+  "png",
+  async (chunk: VolumeChunk, signal: AbortSignal, response: ArrayBuffer) => {
+    const chunkDataSize = chunk.chunkDataSize!;
+    const { uint8Array: decoded } = await requestAsyncComputation(
+      decodePng,
+      signal,
+      [response],
+      new Uint8Array(response),
+      chunkDataSize[0],
+      chunkDataSize[1],
+      chunkDataSize[0] * chunkDataSize[1] * chunkDataSize[2],
+      4,
+      1,
+      false,
+    );
+    await postProcessRawData(chunk, signal, decoded);
+  },
+);
+chunkDecoders.set(
+  "png16",
+  async (chunk: VolumeChunk, signal: AbortSignal, response: ArrayBuffer) => {
+    const chunkDataSize = chunk.chunkDataSize!;
+    const { uint8Array: decoded } = await requestAsyncComputation(
+      decodePng,
+      signal,
+      [response],
+      new Uint8Array(response),
+      chunkDataSize[0],
+      chunkDataSize[1],
+      chunkDataSize[0] * chunkDataSize[1] * chunkDataSize[2],
+      1,
+      2,
+      false,
     );
     await postProcessRawData(chunk, signal, decoded);
   },
@@ -99,6 +138,10 @@ export class TileChunkSource extends WithParameters(
     let imageMethod: string;
     if (parameters.encoding === "raw16") {
       imageMethod = "raw16-image";
+    } else if (parameters.encoding === "png16") {
+      imageMethod = "png16-image";
+    } else if (parameters.encoding === "png") {
+      imageMethod = "png-image";
     } else {
       imageMethod = "jpeg-image";
     }

--- a/src/datasource/render/backend.ts
+++ b/src/datasource/render/backend.ts
@@ -60,26 +60,18 @@ export class TileChunkSource extends WithParameters(
 
   queryString = (() => {
     const { parameters } = this;
-	const query_keys: (keyof TileChunkSourceParameters)[] = [
-		"channel",
-		"minIntensity",
-		"maxIntensity",
-		"maxTileSpecsToRender",
-		"filter"
-	]
-
     const query_params = new URLSearchParams();
-	for (const key of query_keys) {
-		const value = parameters[key];
-		if (value === undefined)
-			continue;
 
-		const serialized = (typeof value === 'object') ? JSON.stringify(value) : String(value);
-		query_params.append(key, serialized);
-
+	if (parameters.channel !== undefined) {
+		query_params.append("channel", parameters.channel);
 	}
 
-    return query_params.toString();
+	// Parse fallback key-value argument
+	for (const [key, value] of Object.entries(parameters.renderArgs)) {
+		query_params.append(key, value);
+	}
+
+	return query_params.toString();
   })();
 
   async download(chunk: VolumeChunk, signal: AbortSignal) {

--- a/src/datasource/render/backend.ts
+++ b/src/datasource/render/backend.ts
@@ -60,31 +60,26 @@ export class TileChunkSource extends WithParameters(
 
   queryString = (() => {
     const { parameters } = this;
-    const query_params: string[] = [];
-    if (parameters.channel !== undefined) {
-      query_params.push("channels=" + parameters.channel);
-    }
-    if (parameters.minIntensity !== undefined) {
-      query_params.push(
-        `minIntensity=${JSON.stringify(parameters.minIntensity)}`,
-      );
-    }
-    if (parameters.maxIntensity !== undefined) {
-      query_params.push(
-        `maxIntensity=${JSON.stringify(parameters.maxIntensity)}`,
-      );
-    }
-    if (parameters.maxTileSpecsToRender !== undefined) {
-      query_params.push(
-        `maxTileSpecsToRender=${JSON.stringify(
-          parameters.maxTileSpecsToRender,
-        )}`,
-      );
-    }
-    if (parameters.filter !== undefined) {
-      query_params.push(`filter=${JSON.stringify(parameters.filter)}`);
-    }
-    return query_params.join("&");
+	const query_keys: (keyof TileChunkSourceParameters)[] = [
+		"channel",
+		"minIntensity",
+		"maxIntensity",
+		"maxTileSpecsToRender",
+		"filter"
+	]
+
+    const query_params = new URLSearchParams();
+	for (const key of query_keys) {
+		const value = parameters[key];
+		if (value === undefined)
+			continue;
+
+		const serialized = (typeof value === 'object') ? JSON.stringify(value) : String(value);
+		query_params.append(key, serialized);
+
+	}
+
+    return query_params.toString();
   })();
 
   async download(chunk: VolumeChunk, signal: AbortSignal) {

--- a/src/datasource/render/base.ts
+++ b/src/datasource/render/base.ts
@@ -23,7 +23,7 @@ export class RenderBaseSourceParameters {
 }
 
 export class RenderSourceParameters extends RenderBaseSourceParameters {
-  renderArgs: {[index: string]: string};
+  renderArgs: { [index: string]: string };
 }
 
 export class TileChunkSourceParameters extends RenderSourceParameters {

--- a/src/datasource/render/base.ts
+++ b/src/datasource/render/base.ts
@@ -23,10 +23,7 @@ export class RenderBaseSourceParameters {
 }
 
 export class RenderSourceParameters extends RenderBaseSourceParameters {
-  minIntensity: number | undefined;
-  maxIntensity: number | undefined;
-  maxTileSpecsToRender: number | undefined;
-  filter: boolean | undefined;
+  renderArgs: {[index: string]: string};
 }
 
 export class TileChunkSourceParameters extends RenderSourceParameters {

--- a/src/datasource/render/frontend.ts
+++ b/src/datasource/render/frontend.ts
@@ -271,37 +271,43 @@ function parseStackProject(stackIdObj: any): string {
 
 function parseQueryParameterInfo(obj: any): QueryParameterInfo[] {
   const boxImageApiKey =
-    "/v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/raw-image"
+    "/v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/raw-image";
   const boxImageApi = obj.paths[boxImageApiKey];
   if (boxImageApi === undefined) {
     // Could not retrieve api, skipping parameter hints
     throw null;
   }
 
-  const boxImageParameters =
-    boxImageApi.get.parameters as Array<{name: string, type: string, required?: boolean }>;
+  const boxImageParameters = boxImageApi.get.parameters as Array<{
+    name: string;
+    type: string;
+    required?: boolean;
+  }>;
 
   // Return optional parameters from render API and extend list with hardcoded options
   return boxImageParameters
     .filter(({ required }) => required === false)
     .filter(({ name }) => name !== "scale")
     .concat([
-      ({ name: "minX", type: "number" }),
-      ({ name: "minY", type: "number" }),
-      ({ name: "minZ", type: "number" }),
-      ({ name: "maxX", type: "number" }),
-      ({ name: "maxY", type: "number" }),
-      ({ name: "maxZ", type: "number" }),
-      ({ name: "encoding", type: Array.from(VALID_ENCODINGS).join(" | ") }),
-      ({ name: "numLevels", type: "integer" }),
-      ({ name: "tileSize", type: "number" }),
-      ({ name: "channel", type: "string" }),
+      { name: "minX", type: "number" },
+      { name: "minY", type: "number" },
+      { name: "minZ", type: "number" },
+      { name: "maxX", type: "number" },
+      { name: "maxY", type: "number" },
+      { name: "maxZ", type: "number" },
+      { name: "encoding", type: Array.from(VALID_ENCODINGS).join(" | ") },
+      { name: "numLevels", type: "integer" },
+      { name: "tileSize", type: "number" },
+      { name: "channel", type: "string" },
     ]);
 }
 
 class RenderMultiscaleVolumeChunkSource extends MultiscaleVolumeChunkSource {
   get dataType() {
-    if (this.parameters.encoding === "raw16" || this.parameters.encoding === "png16") {
+    if (
+      this.parameters.encoding === "raw16" ||
+      this.parameters.encoding === "png16"
+    ) {
       return DataType.UINT16;
     }
     // 8-bit (JPEG or PNG)
@@ -329,7 +335,7 @@ class RenderMultiscaleVolumeChunkSource extends MultiscaleVolumeChunkSource {
   maxZ: number | undefined;
 
   // Key-value pairs to forward to the render webservice
-  renderArgs: {[index: string]: string};
+  renderArgs: { [index: string]: string };
 
   get rank() {
     return 3;
@@ -375,18 +381,27 @@ class RenderMultiscaleVolumeChunkSource extends MultiscaleVolumeChunkSource {
     this.stackInfo = stackInfo;
 
     if (channel !== undefined && channel.length > 0) {
-        this.channel = channel;
+      this.channel = channel;
     }
 
-    const reservedKeys = new Set(["minX", "minY", "minZ", "maxX", "maxY", "maxZ",
-                                 "encoding", "numLevels", "tileSize", "channel"])
+    const reservedKeys = new Set([
+      "minX",
+      "minY",
+      "minZ",
+      "maxX",
+      "maxY",
+      "maxZ",
+      "encoding",
+      "numLevels",
+      "tileSize",
+      "channel",
+    ]);
 
-    this.renderArgs = {}
+    this.renderArgs = {};
     for (const [key, value] of Object.entries(parameters)) {
-        if (reservedKeys.has(key))
-            continue
+      if (reservedKeys.has(key)) continue;
 
-        this.renderArgs[key] = value
+      this.renderArgs[key] = value;
     }
 
     this.minX = verifyOptionalInt(parameters.minX);
@@ -757,11 +772,11 @@ export async function queryParameterCompleter(
     options,
   );
 
-  const idx = query.lastIndexOf('&');
-  const offset = (idx === -1) ? 0 : idx + 1;
+  const idx = query.lastIndexOf("&");
+  const offset = idx === -1 ? 0 : idx + 1;
   const keyValuePair = query.slice(offset);
 
-  const [key, ] = keyValuePair.split('=');
+  const [key] = keyValuePair.split("=");
 
   const completions = getPrefixMatchesWithDescriptions(
     key,
@@ -785,7 +800,7 @@ export async function volumeCompleter(
   const hostname = match[1];
   const path = match[2];
 
-  const [volume, query] = path.split('?');
+  const [volume, query] = path.split("?");
 
   let offset = match![1].length + 1;
   if (query === undefined) {

--- a/src/datasource/render/frontend.ts
+++ b/src/datasource/render/frontend.ts
@@ -67,16 +67,16 @@ import type { ProgressOptions } from "#src/util/progress_listener.js";
 
 const VALID_ENCODINGS = new Set<string>(["jpg", "raw16", "png", "png16"]);
 const RESERVED_PARAMETERS = [
-	{ name: "minX", type: "number" },
-	{ name: "minY", type: "number" },
-	{ name: "minZ", type: "number" },
-	{ name: "maxX", type: "number" },
-	{ name: "maxY", type: "number" },
-	{ name: "maxZ", type: "number" },
-	{ name: "encoding", type: Array.from(VALID_ENCODINGS).join(" | ") },
-	{ name: "numLevels", type: "integer" },
-	{ name: "tileSize", type: "number" },
-	{ name: "channel", type: "string" },
+  { name: "minX", type: "number" },
+  { name: "minY", type: "number" },
+  { name: "minZ", type: "number" },
+  { name: "maxX", type: "number" },
+  { name: "maxY", type: "number" },
+  { name: "maxZ", type: "number" },
+  { name: "encoding", type: Array.from(VALID_ENCODINGS).join(" | ") },
+  { name: "numLevels", type: "integer" },
+  { name: "tileSize", type: "number" },
+  { name: "channel", type: "string" },
 ];
 
 const TileChunkSourceBase = WithParameters(
@@ -385,7 +385,7 @@ class RenderMultiscaleVolumeChunkSource extends MultiscaleVolumeChunkSource {
       this.channel = channel;
     }
 
-	const reservedKeys = new Set(RESERVED_PARAMETERS.map(({ name }) => name));
+    const reservedKeys = new Set(RESERVED_PARAMETERS.map(({ name }) => name));
 
     this.renderArgs = {};
     for (const [key, value] of Object.entries(parameters)) {

--- a/src/datasource/render/frontend.ts
+++ b/src/datasource/render/frontend.ts
@@ -65,7 +65,7 @@ import {
 } from "#src/util/json.js";
 import type { ProgressOptions } from "#src/util/progress_listener.js";
 
-const VALID_ENCODINGS = new Set<string>(["jpg", "raw16"]);
+const VALID_ENCODINGS = new Set<string>(["jpg", "raw16", "png", "png16"]);
 
 const TileChunkSourceBase = WithParameters(
   VolumeChunkSource,
@@ -292,7 +292,7 @@ function parseQueryParameterInfo(obj: any): QueryParameterInfo[] {
       ({ name: "maxX", type: "number" }),
       ({ name: "maxY", type: "number" }),
       ({ name: "maxZ", type: "number" }),
-      ({ name: "encoding", type: "string" }),
+      ({ name: "encoding", type: Array.from(VALID_ENCODINGS).join(" | ") }),
       ({ name: "numLevels", type: "integer" }),
       ({ name: "tileSize", type: "number" }),
       ({ name: "channel", type: "string" }),
@@ -301,10 +301,10 @@ function parseQueryParameterInfo(obj: any): QueryParameterInfo[] {
 
 class RenderMultiscaleVolumeChunkSource extends MultiscaleVolumeChunkSource {
   get dataType() {
-    if (this.parameters.encoding === "raw16") {
+    if (this.parameters.encoding === "raw16" || this.parameters.encoding === "png16") {
       return DataType.UINT16;
     }
-    // JPEG
+    // 8-bit (JPEG or PNG)
     return DataType.UINT8;
   }
   get volumeType() {

--- a/src/datasource/render/frontend.ts
+++ b/src/datasource/render/frontend.ts
@@ -108,6 +108,7 @@ interface StackInfo {
 interface QueryParameterInfo {
   name: string;
   type: string;
+  required?: boolean;
 }
 
 function parseOwnerInfo(obj: any): OwnerInfo {
@@ -286,15 +287,13 @@ function parseQueryParameterInfo(obj: any): QueryParameterInfo[] {
     "/v1/owner/{owner}/project/{project}/stack/{stack}/z/{z}/box/{x},{y},{width},{height},{scale}/raw-image";
   const boxImageApi = obj.paths[boxImageApiKey];
   if (boxImageApi === undefined) {
-    // Could not retrieve api, skipping dynamic parameter hints
+    console.warn(
+      "Could not retrieve API schema, skipping dynamic parameter hints",
+    );
     return RESERVED_PARAMETERS;
   }
 
-  const boxImageParameters = boxImageApi.get.parameters as Array<{
-    name: string;
-    type: string;
-    required?: boolean;
-  }>;
+  const boxImageParameters = boxImageApi.get.parameters as QueryParameterInfo[];
 
   // Return optional parameters from render API and extend list with hardcoded options
   return boxImageParameters
@@ -536,7 +535,7 @@ export function computeStackHierarchy(stackInfo: StackInfo, tileSize: number) {
   return counter;
 }
 
-export function getOwnerInfo(
+export async function getOwnerInfo(
   chunkManager: ChunkManager,
   hostname: string,
   owner: string,
@@ -552,7 +551,7 @@ export function getOwnerInfo(
   );
 }
 
-export function getQueryParameterInfo(
+export async function getQueryParameterInfo(
   chunkManager: ChunkManager,
   hostname: string,
   options: Partial<ProgressOptions>,
@@ -691,7 +690,7 @@ export async function stackAndProjectCompleter(
       (x) => x[0] + "/",
       () => undefined,
     );
-    return { offset: offset, completions };
+    return { offset, completions };
   }
 
   // Autocomplete the stack name
@@ -716,7 +715,7 @@ export async function stackAndProjectCompleter(
         return x[1].project;
       },
     );
-    return { offset: offset, completions };
+    return { offset, completions };
   }
 
   // Autocomplete the channel
@@ -747,7 +746,7 @@ export async function stackAndProjectCompleter(
     (x) => x,
     () => undefined,
   );
-  return { offset: offset, completions };
+  return { offset, completions };
 }
 
 export async function queryParameterCompleter(
@@ -774,7 +773,7 @@ export async function queryParameterCompleter(
     (x) => x.name,
     (x) => x.type,
   );
-  return { offset: offset, completions };
+  return { offset, completions };
 }
 
 export async function volumeCompleter(


### PR DESCRIPTION
@trautmane & @stephanpreibisch, this is a test-PR to discuss the changes with you before making a PR to the original repository.

As announced, I extended the functionality of the render backend of neuroglancer to have more control over rendering. The goal of this is to make our lives a little easier and keep up to date with the ongoing transition to 16bit stacks as the default. To this end, I made the some changes to the handling query parameters (i.e., parameters that are added as `?key=value` to the source). These parameters fall into two categories:
1. Parameters that are handled directly in neuroglancer to call the correct render API (e.g. `encoding`).
2. Parameters that are appended to the render API call as optional arguments (e.g., `maxTileSpecsToRender`).

These are the changes made:
- Parameters of the second category have been hard-coded before, which limited the parameters that were exposed. Those parameters are now just piped through without hard-coded names. This way, we can use new parameters directly in neuroglancer as soon as we introduce them in render.
- Autocomplete information for all parameters was added. This information is hard-coded for parameters of the first kind (which are defined in neuroglancer, anyway), and is dynamically fetched from the [swagger documentation of the raw-image render API](http://em-services-1.int.janelia.org:8080/swagger-ui/#!/Bounding_Box_Image_APIs/renderRawImageForBox) for parameters of the second kind. See screenshot below.
- PNG support was added both for 8bit and 16bit. For 16bit, this adds an easy way to dynamically render 16bit stacks; for 8bit, this adds a lossless alternative to jpg. 

Are there any potential bugs that I could have introduced, or things that I may have overlooked? I tested the functionality in multiple ways, but I'd be grateful if you could give it a quick test as well (installation is relatively easy, instructions are in the README).

Are there any more features that would be worth introducing in the context of this PR? 


![image](https://github.com/user-attachments/assets/6901f2f2-5a54-4d2d-bc58-05f94be431d8)
